### PR TITLE
Suggest more powerful type for static serving

### DIFF
--- a/static.go
+++ b/static.go
@@ -9,7 +9,7 @@ import (
 // Static is a middleware handler that serves static files in the given directory.
 type Static struct {
 	// Dir is the directory to serve static files from
-	Dir http.Dir
+	Dir http.FileSystem
 	// Prefix is the optional prefix used to serve the static directory content
 	Prefix string
 	// IndexFile defines which file to serve as index if it exists.


### PR DESCRIPTION
In order to allow static file serving also from maps, in-app-assets and easy mocking of file accesses, just use the http.FileSystem type here.

Note: This is untested code. Will provide tested code, if the idea is welcome.
