### PR TITLE
Adding in an exported method that allows clients to retrieve a full list of Handlers for the current Negroni chain.

### DIFF
--- a/negroni.go
+++ b/negroni.go
@@ -92,6 +92,11 @@ func (n *Negroni) Run(addr string) {
 	l.Fatal(http.ListenAndServe(addr, n))
 }
 
+// Returns a list of all the handlers in the current Negroni middleware chain.
+func (n *Negroni) Handlers() ([]Handler) {
+	return n.handlers
+}
+
 func build(handlers []Handler) middleware {
 	var next middleware
 

--- a/negroni_test.go
+++ b/negroni_test.go
@@ -50,3 +50,26 @@ func TestNegroniServeHTTP(t *testing.T) {
 	expect(t, result, "foobarbatbazban")
 	expect(t, response.Code, http.StatusBadRequest)
 }
+
+// Ensures that a Negroni middleware chain 
+// can correctly return all of its handlers.
+func TestHandlers(t *testing.T) {
+	response := httptest.NewRecorder()
+	n := New()
+	handlers := n.Handlers()
+	expect(t, 0, len(handlers))
+
+	n.Use(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+
+	// Expects the length of handlers to be exactly 1 
+	// after adding exactly one handler to the middleware chain
+	handlers = n.Handlers()
+	expect(t, 1, len(handlers))
+
+	// Ensures that the first handler that is in sequence behaves
+	// exactly the same as the one that was registered earlier
+	handlers[0].ServeHTTP(response, (*http.Request)(nil), nil)
+	expect(t, response.Code, http.StatusOK)
+}


### PR DESCRIPTION
Hello there!

First off, thanks for the great library :smile:!  It's been very helpful in providing much needed diagnostics for our internal golang services and for some of my experimental projects as well.

Lately, I've been wishing that the library had a way to inspect the full list of Handlers so that I might be able to create more flexible middleware.  For example, this might be useful when you want to reflect on your final `http.Handler` in order to efficiently handle Content-Type Encoding negotiation, Request Body mismatches, or provide other interesting diagnostic information.

This PR is intended to provide clients of `negroni` this ability by returning a list of all the Handlers for any given Negroni middleware chain for inspection.

Let me know what you think, and thanks again!
