### PR TITLE
Replaced debug.Stack with runtime.Stack. Added two new options to recover.

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -5,13 +5,15 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"runtime/debug"
+	"runtime"
 )
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
 	Logger     *log.Logger
 	PrintStack bool
+	StackAll   bool
+	StackSize  int
 }
 
 // NewRecovery returns a new instance of Recovery
@@ -19,6 +21,8 @@ func NewRecovery() *Recovery {
 	return &Recovery{
 		Logger:     log.New(os.Stdout, "[negroni] ", 0),
 		PrintStack: true,
+		StackAll:   false,
+		StackSize:  1024 * 4,
 	}
 }
 
@@ -26,7 +30,9 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 	defer func() {
 		if err := recover(); err != nil {
 			rw.WriteHeader(http.StatusInternalServerError)
-			stack := debug.Stack()
+			stack := make([]byte, rec.StackSize)
+			stack = stack[:runtime.Stack(stack, rec.StackAll)]
+
 			f := "PANIC: %s\n%s"
 			rec.Logger.Printf(f, err, stack)
 


### PR DESCRIPTION
I noticed runtime.debug.Stack was deprecated, so I replaced it with the recommended runtime.Stack. Along with the new new implementation, a few options emerged. StackAll would be useful if you needed a dump of the entire app, and if you dumped the app (every goroutine) you are going to need a pretty big byte slice to hold the data.. hence the StackSize option.
