### PR TITLE
Make WriteHeader set status before calling beforeFuncs

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -39,9 +39,9 @@ type responseWriter struct {
 }
 
 func (rw *responseWriter) WriteHeader(s int) {
+	rw.status = s
 	rw.callBefore()
 	rw.ResponseWriter.WriteHeader(s)
-	rw.status = s
 }
 
 func (rw *responseWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
so middlewares can do stuff based on the resulting status code of the request. 

Fixes #55 
