### PR TITLE
Update route specific handling example to use PathPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,17 @@ If you have a route group of routes that need specific middleware to be executed
 
 ~~~ go
 router := mux.NewRouter()
-adminRoutes := mux.NewRouter()
-// add admin routes here
+apiRoutes := mux.NewRouter()
+// add api routes here
+// eg apiRoutes.HandleFunc("/api", apiHandler)
+// eg apiRoutes.HandleFunc("/api/users", userHandler)
+// eg apiRoutes.HandleFunc("/api/products", productHandler)
 
-// Create a new negroni for the admin middleware
-router.Handle("/admin", negroni.New(
+// Create a new negroni for the api middleware
+router.PathPrefix("/api").Handler( negroni.New(
   Middleware1,
   Middleware2,
-  negroni.Wrap(adminRoutes),
+  negroni.Wrap(apiRoutes),
 ))
 ~~~
 


### PR DESCRIPTION
The route specific example only works with one specific URL path. In order to run middleware under an entire route (eg /api in this example), PathPrefix must be used to create a matching route on the root handler.
