### PR TITLE
Recover panics thrown by the Recovery handler ErrorHandlerFunc

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"runtime/debug"
 )
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
@@ -35,6 +36,7 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 
 			rw.WriteHeader(http.StatusInternalServerError)
+
 			stack := make([]byte, rec.StackSize)
 			stack = stack[:runtime.Stack(stack, rec.StackAll)]
 
@@ -46,6 +48,12 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 
 			if rec.ErrorHandlerFunc != nil {
+				defer func() {
+					if err := recover(); err != nil {
+						rec.Logger.Printf("provided ErrorHandlerFunc panic'd: %s, trace:\n%s", err, debug.Stack())
+						rec.Logger.Printf("%s\n", debug.Stack())
+					}
+				}()
 				rec.ErrorHandlerFunc(err)
 			}
 		}

--- a/recovery.go
+++ b/recovery.go
@@ -48,13 +48,15 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 
 			if rec.ErrorHandlerFunc != nil {
-				defer func() {
-					if err := recover(); err != nil {
-						rec.Logger.Printf("provided ErrorHandlerFunc panic'd: %s, trace:\n%s", err, debug.Stack())
-						rec.Logger.Printf("%s\n", debug.Stack())
-					}
+				func() {
+					defer func() {
+						if err := recover(); err != nil {
+							rec.Logger.Printf("provided ErrorHandlerFunc panic'd: %s, trace:\n%s", err, debug.Stack())
+							rec.Logger.Printf("%s\n", debug.Stack())
+						}
+					}()
+					rec.ErrorHandlerFunc(err)
 				}()
-				rec.ErrorHandlerFunc(err)
 			}
 		}
 	}()

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -2,18 +2,24 @@ package negroni
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func TestRecovery(t *testing.T) {
 	buff := bytes.NewBufferString("")
 	recorder := httptest.NewRecorder()
+	handlerCalled := false
 
 	rec := NewRecovery()
 	rec.Logger = log.New(buff, "[negroni] ", 0)
+	rec.ErrorHandlerFunc = func(i interface{}) {
+		handlerCalled = true
+	}
 
 	n := New()
 	// replace log for testing
@@ -24,6 +30,7 @@ func TestRecovery(t *testing.T) {
 	n.ServeHTTP(recorder, (*http.Request)(nil))
 	expect(t, recorder.Header().Get("Content-Type"), "text/plain; charset=utf-8")
 	expect(t, recorder.Code, http.StatusInternalServerError)
+	expect(t, handlerCalled, true)
 	refute(t, recorder.Body.Len(), 0)
 	refute(t, len(buff.String()), 0)
 }
@@ -42,4 +49,25 @@ func TestRecovery_noContentTypeOverwrite(t *testing.T) {
 	}))
 	n.ServeHTTP(recorder, (*http.Request)(nil))
 	expect(t, recorder.Header().Get("Content-Type"), "application/javascript; charset=utf-8")
+}
+
+func TestRecovery_callbackPanic(t *testing.T) {
+	buff := bytes.NewBufferString("")
+	recorder := httptest.NewRecorder()
+
+	rec := NewRecovery()
+	rec.Logger = log.New(buff, "[negroni] ", 0)
+	rec.ErrorHandlerFunc = func(i interface{}) {
+		panic("callback panic")
+	}
+
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		panic("here is a panic!")
+	}))
+	n.ServeHTTP(recorder, (*http.Request)(nil))
+
+	expect(t, strings.Contains(buff.String(), "callback panic"), true)
+	fmt.Println(buff.String())
 }


### PR DESCRIPTION
If the user specified function itself panic's, catch and log.

(also adds a check to the happy path test to make sure the handler was called)

See discussion in #134.

cc/ @pjebs

@meatballhat I'm curious if you have any thoughts about the discussion in #134 and this implementation.