### PR TITLE
Introduce ALogger interface

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -7,10 +7,16 @@ import (
 	"time"
 )
 
+// ALogger interface
+type ALogger interface {
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
 // Logger is a middleware handler that logs the request as it goes in and the response as it goes out.
 type Logger struct {
-	// Logger inherits from log.Logger used to log messages with the Logger middleware
-	*log.Logger
+	// ALogger implements just enough log.Logger interface to be compatible with other implementations
+	ALogger
 }
 
 // NewLogger returns a new Logger instance

--- a/logger_test.go
+++ b/logger_test.go
@@ -13,7 +13,7 @@ func Test_Logger(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	l := NewLogger()
-	l.Logger = log.New(buff, "[negroni] ", 0)
+	l.ALogger = log.New(buff, "[negroni] ", 0)
 
 	n := New()
 	// replace log for testing

--- a/recovery.go
+++ b/recovery.go
@@ -11,7 +11,7 @@ import (
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
-	Logger           *log.Logger
+	Logger           ALogger
 	PrintStack       bool
 	ErrorHandlerFunc func(interface{})
 	StackAll         bool


### PR DESCRIPTION
Abstract out the log.Logger interface so we can replace it at
configuration time with compatible implementations

This change for example would allow you to replace log.ALogger
with Sirupsen/Logger which has a compatible implementation with
log.Logger with no other changes.