### PR TITLE
Take a `logger` interface rather than a concrete *log.Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
   previously `200` (in 0.2.0, before that it was `0` so this reestablishes that
   behavior)
 - Catch `panic`s thrown by callbacks provided to the `Recovery` handler
+- Switch `log.Logger`s to an interface to allow injection of `logrus` or other
+  logging libraries that have similar interfaces
 
 ## [0.2.0] - 2016-05-10
 ### Added

--- a/logger.go
+++ b/logger.go
@@ -9,8 +9,7 @@ import (
 
 // Logger is a middleware handler that logs the request as it goes in and the response as it goes out.
 type Logger struct {
-	// Logger inherits from log.Logger used to log messages with the Logger middleware
-	*log.Logger
+	Logger logger
 }
 
 // NewLogger returns a new Logger instance
@@ -20,10 +19,10 @@ func NewLogger() *Logger {
 
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
-	l.Printf("Started %s %s", r.Method, r.URL.Path)
+	l.Logger.Printf("Started %s %s", r.Method, r.URL.Path)
 
 	next(rw, r)
 
 	res := rw.(ResponseWriter)
-	l.Printf("Completed %v %s in %v", res.Status(), http.StatusText(res.Status()), time.Since(start))
+	l.Logger.Printf("Completed %v %s in %v", res.Status(), http.StatusText(res.Status()), time.Since(start))
 }

--- a/negroni.go
+++ b/negroni.go
@@ -33,6 +33,12 @@ func (m middleware) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	m.handler.ServeHTTP(rw, r, m.next.ServeHTTP)
 }
 
+// logger implements just enough log.Logger interface to be compatible with other implementations
+type logger interface {
+	Println(v ...interface{})
+	Printf(format string, v ...interface{})
+}
+
 // Wrap converts a http.Handler into a negroni.Handler so it can be used as a Negroni
 // middleware. The next http.HandlerFunc is automatically called after the Handler
 // is executed.

--- a/recovery.go
+++ b/recovery.go
@@ -11,7 +11,7 @@ import (
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
-	Logger           *log.Logger
+	Logger           logger
 	PrintStack       bool
 	ErrorHandlerFunc func(interface{})
 	StackAll         bool


### PR DESCRIPTION
Create a private `logger` interface that the library can use in places
where it desires a logger to allow the user to inject `logrus.Logger` or
other structs with a similar interface.

Inspired by #141