### PR TITLE
Passing custom logger during initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ package main
 
 import (
   "fmt"
+  "log"
   "net/http"
 
   "github.com/urfave/negroni"
@@ -371,7 +372,7 @@ func main() {
   })
 
   n := negroni.New()
-  n.Use(negroni.NewLogger())
+  n.Use(negroni.NewLogger(log.New(os.Stdout, "[app]", log.Lshortfile)))
   n.UseHandler(mux)
 
   http.ListenAndServe(":3004", n)
@@ -381,8 +382,8 @@ func main() {
 Will print a log similar to:
 
 ```
-[negroni] Started GET /
-[negroni] Completed 200 OK in 145.446µs
+[app]logger.go:28: Started GET /
+[app]logger.go:28: Completed 200 OK in 145.446µs
 ```
 
 on each request.

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Example:
 package main
 
 import (
+  "log"
   "net/http"
 
   "github.com/urfave/negroni"
@@ -304,7 +305,7 @@ func main() {
   })
 
   n := negroni.New()
-  n.Use(negroni.NewRecovery())
+  n.Use(negroni.NewRecovery(log.New(os.Stdout, "[app] ", log.Lshortfile)))
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
@@ -321,6 +322,7 @@ Example with error handler:
 package main
 
 import (
+  "log"
   "net/http"
 
   "github.com/urfave/negroni"
@@ -333,7 +335,7 @@ func main() {
   })
 
   n := negroni.New()
-  recovery := negroni.NewRecovery()
+  recovery := negroni.NewRecovery(log.New(os.Stdout, "[app] ", log.Lshortfile))
   recovery.ErrorHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)

--- a/logger.go
+++ b/logger.go
@@ -3,7 +3,6 @@ package negroni
 import (
 	"log"
 	"net/http"
-	"os"
 	"time"
 )
 
@@ -20,8 +19,8 @@ type Logger struct {
 }
 
 // NewLogger returns a new Logger instance
-func NewLogger() *Logger {
-	return &Logger{log.New(os.Stdout, "[negroni] ", 0)}
+func NewLogger(l *log.Logger) *Logger {
+	return &Logger{l}
 }
 
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {

--- a/logger.go
+++ b/logger.go
@@ -7,7 +7,7 @@ import (
 )
 
 // ALogger interface
-type ALogger interface {
+type aLogger interface {
 	Println(v ...interface{})
 	Printf(format string, v ...interface{})
 }
@@ -15,7 +15,7 @@ type ALogger interface {
 // Logger is a middleware handler that logs the request as it goes in and the response as it goes out.
 type Logger struct {
 	// ALogger implements just enough log.Logger interface to be compatible with other implementations
-	ALogger
+	aLogger
 }
 
 // NewLogger returns a new Logger instance

--- a/logger_test.go
+++ b/logger_test.go
@@ -12,8 +12,7 @@ func Test_Logger(t *testing.T) {
 	buff := bytes.NewBufferString("")
 	recorder := httptest.NewRecorder()
 
-	l := NewLogger()
-	l.ALogger = log.New(buff, "[negroni] ", 0)
+	l := NewLogger(log.New(buff, "[negroni] ", 0))
 
 	n := New()
 	// replace log for testing

--- a/negroni.go
+++ b/negroni.go
@@ -66,7 +66,7 @@ func New(handlers ...Handler) *Negroni {
 // Logger - Request/Response Logging
 // Static - Static File Serving
 func Classic() *Negroni {
-	return New(NewRecovery(),
+	return New(NewRecovery(log.New(os.Stdout, "[negroni] ", 0)),
 		NewLogger(log.New(os.Stdout, "[negroni] ", 0)),
 		NewStatic(http.Dir("public")))
 }

--- a/negroni.go
+++ b/negroni.go
@@ -66,7 +66,9 @@ func New(handlers ...Handler) *Negroni {
 // Logger - Request/Response Logging
 // Static - Static File Serving
 func Classic() *Negroni {
-	return New(NewRecovery(), NewLogger(), NewStatic(http.Dir("public")))
+	return New(NewRecovery(),
+		NewLogger(log.New(os.Stdout, "[negroni] ", 0)),
+		NewStatic(http.Dir("public")))
 }
 
 func (n *Negroni) ServeHTTP(rw http.ResponseWriter, r *http.Request) {

--- a/recovery.go
+++ b/recovery.go
@@ -10,7 +10,7 @@ import (
 
 // Recovery is a Negroni middleware that recovers from any panics and writes a 500 if there was one.
 type Recovery struct {
-	Logger           ALogger
+	logger           aLogger
 	PrintStack       bool
 	ErrorHandlerFunc func(interface{})
 	StackAll         bool
@@ -20,7 +20,7 @@ type Recovery struct {
 // NewRecovery returns a new instance of Recovery
 func NewRecovery(l *log.Logger) *Recovery {
 	return &Recovery{
-		Logger:     l,
+		logger:     l,
 		PrintStack: true,
 		StackAll:   false,
 		StackSize:  1024 * 8,
@@ -40,7 +40,7 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			stack = stack[:runtime.Stack(stack, rec.StackAll)]
 
 			f := "PANIC: %s\n%s"
-			rec.Logger.Printf(f, err, stack)
+			rec.logger.Printf(f, err, stack)
 
 			if rec.PrintStack {
 				fmt.Fprintf(rw, f, err, stack)
@@ -50,8 +50,8 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 				func() {
 					defer func() {
 						if err := recover(); err != nil {
-							rec.Logger.Printf("provided ErrorHandlerFunc panic'd: %s, trace:\n%s", err, debug.Stack())
-							rec.Logger.Printf("%s\n", debug.Stack())
+							rec.logger.Printf("provided ErrorHandlerFunc panic'd: %s, trace:\n%s", err, debug.Stack())
+							rec.logger.Printf("%s\n", debug.Stack())
 						}
 					}()
 					rec.ErrorHandlerFunc(err)

--- a/recovery.go
+++ b/recovery.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"os"
 	"runtime"
 	"runtime/debug"
 )
@@ -19,9 +18,9 @@ type Recovery struct {
 }
 
 // NewRecovery returns a new instance of Recovery
-func NewRecovery() *Recovery {
+func NewRecovery(l *log.Logger) *Recovery {
 	return &Recovery{
-		Logger:     log.New(os.Stdout, "[negroni] ", 0),
+		Logger:     l,
 		PrintStack: true,
 		StackAll:   false,
 		StackSize:  1024 * 8,

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -14,8 +14,7 @@ func TestRecovery(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	handlerCalled := false
 
-	rec := NewRecovery()
-	rec.Logger = log.New(buff, "[negroni] ", 0)
+	rec := NewRecovery(log.New(buff, "[negroni] ", 0))
 	rec.ErrorHandlerFunc = func(i interface{}) {
 		handlerCalled = true
 	}
@@ -37,8 +36,7 @@ func TestRecovery(t *testing.T) {
 func TestRecovery_noContentTypeOverwrite(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	rec := NewRecovery()
-	rec.Logger = log.New(bytes.NewBuffer([]byte{}), "[negroni] ", 0)
+	rec := NewRecovery(log.New(bytes.NewBuffer([]byte{}), "[negroni] ", 0))
 
 	n := New()
 	n.Use(rec)
@@ -54,8 +52,7 @@ func TestRecovery_callbackPanic(t *testing.T) {
 	buff := bytes.NewBufferString("")
 	recorder := httptest.NewRecorder()
 
-	rec := NewRecovery()
-	rec.Logger = log.New(buff, "[negroni] ", 0)
+	rec := NewRecovery(log.New(buff, "[negroni] ", 0))
 	rec.ErrorHandlerFunc = func(i interface{}) {
 		panic("callback panic")
 	}


### PR DESCRIPTION
This makes the API more elegant for people who want to pass their own loggers. Prevents code like this -
```go
n := negroni.New()
nRecover := negroni.NewRecovery()
nRecover.Logger = logger
n.Use(nRecover)
nLogger := negroni.NewLogger()
nLogger.ALogger = logger
n.Use(nLogger)
```

I understand this breaks the API for `NewRecovery()` and `NewLogger()` but people wanting to explicitly call these would usually want better control over their code. Otherwise, they can simply call `Classic()`. Now since the call to `Classic()` remains the same, I would think we have more to gain by improving the API than by keeping it the same and forcing users to do it in a round-about way.