### PR TITLE
Mark responses as written if Flush()ed

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -94,6 +94,10 @@ func (rw *responseWriter) callBefore() {
 func (rw *responseWriter) Flush() {
 	flusher, ok := rw.ResponseWriter.(http.Flusher)
 	if ok {
+		if !rw.Written() {
+			// The status will be StatusOK if WriteHeader has not been called yet
+			rw.WriteHeader(http.StatusOK)
+		}
 		flusher.Flush()
 	}
 }

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -170,3 +170,12 @@ func TestResponseWriterFlusher(t *testing.T) {
 	_, ok := rw.(http.Flusher)
 	expect(t, ok, true)
 }
+
+func TestResponseWriter_Flush_marksWritten(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.Flush()
+	expect(t, rw.Status(), http.StatusOK)
+	expect(t, rw.Written(), true)
+}


### PR DESCRIPTION
Currently, it delegates the Flush() call, but this causes the
WriteHeader() call to go to the embedded type rather than to the
`negroni.ResponseWriter` which means we miss that the status was written
(similar to what we do in `ResponseWriter.Write()`).

Fixes #149