### PR TITLE
ResponseWriter and CloseNotifier

### DIFF
--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -163,6 +163,12 @@ func TestResponseWriterCloseNotify(t *testing.T) {
 	expect(t, closed, true)
 }
 
+func TestResponseWriterNonCloseNotify(t *testing.T) {
+	rw := NewResponseWriter(httptest.NewRecorder())
+	_, ok := rw.(http.CloseNotifier)
+	expect(t, ok, false)
+}
+
 func TestResponseWriterFlusher(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)


### PR DESCRIPTION
I ran into a problem when I attempted to use code that tested if `negroni.ResponseWriter` implemented `http.CloseNotifier`:

```
ctx, cancel = context.WithCancel(context.Background())

if cn, ok := w.(http.CloseNotifier); ok {
	closeNotify := cn.CloseNotify()
	done := ctx.Done()

	go func() {
		select {
		case <-done:
		case <-closeNotify:
			cancel()
		}
	}()
}
```

This caused a panic, because `negroni.ResponseWriter` does indeed implement `http.CloseNotifier`, but the underlying `http.ResponseWriter` didn't (it was in a test that used `httptest.ResponseRecoder`, fwiw).

This patch makes a new `responseWriterCloseNotifer` struct which is returned by `NewResponseWriter` if needed. Consequently, `responseWriter` doesn't falsely advertise that is implements `http.CloseNotifer`.

I'm not entirely sure if this is the best approach. ~~`Hijack` and `Flush` simply return errors when in a similar situation.~~ Correction: `Hijack` returns an error (not `Flush`). But, that's not possible here since `CloseNotify` doesn't return an `error`. A dummy CloseNotify implementation could work, I guess. But, it seems wasteful to open an unnecessary channel and I'd rather test for `http.CloseNotifier` and to do the right thing.