### PR TITLE
Make the logger more verbose.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -26,10 +26,9 @@ func NewLogger() *Logger {
 
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	start := time.Now()
-	l.Printf("Started %s %s", r.Method, r.URL.Path)
 
 	next(rw, r)
 
 	res := rw.(ResponseWriter)
-	l.Printf("Completed %v %s in %v", res.Status(), http.StatusText(res.Status()), time.Since(start))
+	l.Printf("%v | %v | \t %v | %v | %v %v", start.Format(time.RFC3339), res.Status(), time.Since(start), r.Host, r.Method, r.URL.Path)
 }

--- a/logger.go
+++ b/logger.go
@@ -1,11 +1,35 @@
 package negroni
 
 import (
+	"bytes"
+
 	"log"
 	"net/http"
 	"os"
+	"sync"
+	"text/template"
 	"time"
 )
+
+// Log is the structure
+// passed to the template.
+type Log struct {
+	StartTime string
+	Status    int
+	Duration  time.Duration
+	Hostname  string
+	Method    string
+	Path      string
+}
+
+// DefaultFormat is the format
+// logged used by the default Logger instance.
+var DefaultFormat = "{{.StartTime}} | {{.Status}} | \t {{.Duration}} | {{.Hostname}} | {{.Method}} {{.Path}} \n"
+
+// DefaultDateFormat is the
+// format used for date by the
+// default Logger instance.
+var DefaultDateFormat = time.RFC3339
 
 // ALogger interface
 type ALogger interface {
@@ -17,11 +41,25 @@ type ALogger interface {
 type Logger struct {
 	// ALogger implements just enough log.Logger interface to be compatible with other implementations
 	ALogger
+	dateFormat string
+	template   *template.Template
+	buffer     *bytes.Buffer
+	mu         sync.Mutex
 }
 
 // NewLogger returns a new Logger instance
 func NewLogger() *Logger {
-	return &Logger{log.New(os.Stdout, "[negroni] ", 0)}
+	logger := &Logger{ALogger: log.New(os.Stdout, "[negroni] ", 0), dateFormat: DefaultDateFormat, buffer: bytes.NewBufferString("")}
+	logger.SetFormat(DefaultFormat)
+	return logger
+}
+
+func (l *Logger) SetFormat(format string) {
+	l.template = template.Must(template.New("negroni_parser").Parse(format))
+}
+
+func (l *Logger) SetDateFormat(format string) {
+	l.dateFormat = format
 }
 
 func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
@@ -30,5 +68,11 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	next(rw, r)
 
 	res := rw.(ResponseWriter)
-	l.Printf("%v | %v | \t %v | %v | %v %v", start.Format(time.RFC3339), res.Status(), time.Since(start), r.Host, r.Method, r.URL.Path)
+	log := Log{start.Format(l.dateFormat), res.Status(), time.Since(start), r.Host, r.Method, r.URL.Path}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.template.Execute(l.buffer, log)
+	l.Printf(l.buffer.String())
+	l.buffer.Reset()
 }


### PR DESCRIPTION
Format the output of the logger with more elements.
Largely inspired by gin.

*(added by @meatballhat:)*

### before

```
[negroni] Started GET /
[negroni] Completed 200 OK in 159.388µs
```

### after

```
[negroni] 2016-12-21T12:05:50-05:00 | 200 |      224.025µs | localhost:3000 | GET /
```