### PR TITLE
Use correct variable in logger.SetFormat call

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -47,7 +47,7 @@ type Logger struct {
 // NewLogger returns a new Logger instance
 func NewLogger() *Logger {
 	logger := &Logger{ALogger: log.New(os.Stdout, "[negroni] ", 0), dateFormat: LoggerDefaultDateFormat}
-	logger.SetFormat(LoggerDefaultDateFormat)
+	logger.SetFormat(LoggerDefaultFormat)
 	return logger
 }
 


### PR DESCRIPTION
It looks like the wrong variable has been used, `LoggerDefaultDateFormat`instead of `LoggerDefaultFormat` in the recent name change. This caused only dates to be logged, rather than the actual log messages.