### PR TITLE
Combine() helper function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,26 @@ n.UseHandler(mux)
 http.ListenAndServe(":3000", n)
 ```
 
+## `Combine()`
+
+Negroni has a convenience function called `Combine`. `Combine` takes one or more
+`Handler` instances and returns a new `Negroni` with the combination of the
+receiver's handlers and the new handlers.
+
+```go
+// middleware we want to reuse
+common := negroni.New()
+common.Use(MyMiddleware1)
+common.Use(MyMiddleware2)
+
+// `specific` is a new negroni with the handlers from `common` combined with the
+// the handlers passed in
+specific := common.Combine(
+	SpecificMiddleware1,
+	SpecificMiddleware2
+)
+```
+
 ## `Run()`
 
 Negroni has a convenience function called `Run`. `Run` takes an addr string
@@ -239,6 +259,36 @@ router.PathPrefix("/subpath").Handler(negroni.New(
   Middleware1,
   Middleware2,
   negroni.Wrap(subRouter),
+))
+```
+
+`Combine()` can be used to eliminate redundancy for middlewares shared across
+routes.
+
+``` go
+router := mux.NewRouter()
+apiRoutes := mux.NewRouter()
+// add api routes here
+webRoutes := mux.NewRouter()
+// add web routes here
+
+// create common middleware to be shared across routes
+common := negroni.New(
+	Middleware1,
+	Middleware2,
+)
+
+// create a new negroni for the api middleware
+// using the common middleware as a base
+router.PathPrefix("/api").Handler(common.Combine(
+  APIMiddleware1,
+  negroni.Wrap(apiRoutes),
+))
+// create a new negroni for the web middleware
+// using the common middleware as a base
+router.PathPrefix("/web").Handler(common.Combine(
+  WebMiddleware1,
+  negroni.Wrap(webRoutes),
 ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ n.UseHandler(mux)
 http.ListenAndServe(":3000", n)
 ```
 
-## `Combine()`
+## `With()`
 
-Negroni has a convenience function called `Combine`. `Combine` takes one or more
+Negroni has a convenience function called `With`. `With` takes one or more
 `Handler` instances and returns a new `Negroni` with the combination of the
 receiver's handlers and the new handlers.
 
@@ -166,7 +166,7 @@ common.Use(MyMiddleware2)
 
 // `specific` is a new negroni with the handlers from `common` combined with the
 // the handlers passed in
-specific := common.Combine(
+specific := common.With(
 	SpecificMiddleware1,
 	SpecificMiddleware2
 )
@@ -262,7 +262,7 @@ router.PathPrefix("/subpath").Handler(negroni.New(
 ))
 ```
 
-`Combine()` can be used to eliminate redundancy for middlewares shared across
+`With()` can be used to eliminate redundancy for middlewares shared across
 routes.
 
 ``` go
@@ -280,13 +280,13 @@ common := negroni.New(
 
 // create a new negroni for the api middleware
 // using the common middleware as a base
-router.PathPrefix("/api").Handler(common.Combine(
+router.PathPrefix("/api").Handler(common.With(
   APIMiddleware1,
   negroni.Wrap(apiRoutes),
 ))
 // create a new negroni for the web middleware
 // using the common middleware as a base
-router.PathPrefix("/web").Handler(common.Combine(
+router.PathPrefix("/web").Handler(common.With(
   WebMiddleware1,
   negroni.Wrap(webRoutes),
 ))

--- a/negroni.go
+++ b/negroni.go
@@ -59,6 +59,14 @@ func New(handlers ...Handler) *Negroni {
 	}
 }
 
+// Combine returns a new Negroni instance that is a combination of the negroni
+// receiver's handlers and the provided handlers.
+func (n *Negroni) Combine(handlers ...Handler) *Negroni {
+	return New(
+		append(n.handlers, handlers...)...,
+	)
+}
+
 // Classic returns a new Negroni instance with the default middleware already
 // in the stack.
 //

--- a/negroni.go
+++ b/negroni.go
@@ -59,9 +59,9 @@ func New(handlers ...Handler) *Negroni {
 	}
 }
 
-// Combine returns a new Negroni instance that is a combination of the negroni
+// With returns a new Negroni instance that is a combination of the negroni
 // receiver's handlers and the provided handlers.
-func (n *Negroni) Combine(handlers ...Handler) *Negroni {
+func (n *Negroni) With(handlers ...Handler) *Negroni {
 	return New(
 		append(n.handlers, handlers...)...,
 	)

--- a/negroni_test.go
+++ b/negroni_test.go
@@ -25,6 +25,39 @@ func TestNegroniRun(t *testing.T) {
 	go New().Run(":3000")
 }
 
+func TestNegroniCombine(t *testing.T) {
+	result := ""
+	response := httptest.NewRecorder()
+
+	n1 := New()
+	n1.Use(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		result = "one"
+		next(rw, r)
+	}))
+	n1.Use(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		result += "two"
+		next(rw, r)
+	}))
+
+	n1.ServeHTTP(response, (*http.Request)(nil))
+	expect(t, 2, len(n1.Handlers()))
+	expect(t, result, "onetwo")
+
+	n2 := n1.Combine(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		result += "three"
+		next(rw, r)
+	}))
+
+	// Verify that n1 was left intact and not modified.
+	n1.ServeHTTP(response, (*http.Request)(nil))
+	expect(t, 2, len(n1.Handlers()))
+	expect(t, result, "onetwo")
+
+	n2.ServeHTTP(response, (*http.Request)(nil))
+	expect(t, 3, len(n2.Handlers()))
+	expect(t, result, "onetwothree")
+}
+
 func TestNegroniServeHTTP(t *testing.T) {
 	result := ""
 	response := httptest.NewRecorder()

--- a/negroni_test.go
+++ b/negroni_test.go
@@ -25,7 +25,7 @@ func TestNegroniRun(t *testing.T) {
 	go New().Run(":3000")
 }
 
-func TestNegroniCombine(t *testing.T) {
+func TestNegroniWith(t *testing.T) {
 	result := ""
 	response := httptest.NewRecorder()
 
@@ -43,7 +43,7 @@ func TestNegroniCombine(t *testing.T) {
 	expect(t, 2, len(n1.Handlers()))
 	expect(t, result, "onetwo")
 
-	n2 := n1.Combine(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	n2 := n1.With(HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 		result += "three"
 		next(rw, r)
 	}))


### PR DESCRIPTION
`Combine` function to address proposed enhancement in #167.

I opted to call it `Combine` instead of `Append`. I thought `Append` might imply that the original negroni is modified, like the builtin `append` does for slices, but that is not what happens here.

