### PR TITLE
Add detection of the address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ func main() {
   n.Run(":8080")
 }
 ```
+If no address is provided, the `PORT` environment variable is used instead.
+If this latest is not defined, the default address will be used. 
+See [Run](https://godoc.org/github.com/urfave/negroni#Negroni.Run) for a complete description.
 
 In general, you will want to use `net/http` methods and pass `negroni` as a
 `Handler`, as this is more flexible, e.g.:

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ func main() {
 }
 ```
 If no address is provided, the `PORT` environment variable is used instead.
-If this latest is not defined, the default address will be used. 
+If the `PORT`environment variable is not defined, the default address will be used. 
 See [Run](https://godoc.org/github.com/urfave/negroni#Negroni.Run) for a complete description.
 
 In general, you will want to use `net/http` methods and pass `negroni` as a

--- a/negroni.go
+++ b/negroni.go
@@ -113,7 +113,7 @@ func (n *Negroni) UseHandlerFunc(handlerFunc func(rw http.ResponseWriter, r *htt
 
 // Run is a convenience function that runs the negroni stack as an HTTP
 // server. The addr string, if provided, takes the same format as http.ListenAndServe.
-// If no address is provided but the PORT environment variable is set, this latest will be used.
+// If no address is provided but the PORT environment variable is set, the PORT value is used.
 // If neither is provided, the address' value will equal the DefaultAddress constant.
 func (n *Negroni) Run(addr ...string) {
 	l := log.New(os.Stdout, "[negroni] ", 0)

--- a/negroni.go
+++ b/negroni.go
@@ -6,6 +6,11 @@ import (
 	"os"
 )
 
+const (
+	// DefaultAddress is used if no other are specified.
+	DefaultAddress = ":8080"
+)
+
 // Handler handler is an interface that objects can implement to be registered to serve as middleware
 // in the Negroni middleware stack.
 // ServeHTTP should yield to the next middleware in the chain by invoking the next http.HandlerFunc
@@ -108,10 +113,20 @@ func (n *Negroni) UseHandlerFunc(handlerFunc func(rw http.ResponseWriter, r *htt
 
 // Run is a convenience function that runs the negroni stack as an HTTP
 // server. The addr string takes the same format as http.ListenAndServe.
-func (n *Negroni) Run(addr string) {
+func (n *Negroni) Run(addr ...string) {
 	l := log.New(os.Stdout, "[negroni] ", 0)
 	l.Printf("listening on %s", addr)
-	l.Fatal(http.ListenAndServe(addr, n))
+	l.Fatal(http.ListenAndServe(detectAddress(addr...), n))
+}
+
+func detectAddress(addr ...string) string {
+	if len(addr) > 0 {
+		return addr[0]
+	}
+	if port := os.Getenv("PORT"); port != "" {
+		return ":" + port
+	}
+	return DefaultAddress
 }
 
 // Returns a list of all the handlers in the current Negroni middleware chain.

--- a/negroni.go
+++ b/negroni.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	// DefaultAddress is used if no other are specified.
+	// DefaultAddress is used if no other is specified.
 	DefaultAddress = ":8080"
 )
 
@@ -112,7 +112,9 @@ func (n *Negroni) UseHandlerFunc(handlerFunc func(rw http.ResponseWriter, r *htt
 }
 
 // Run is a convenience function that runs the negroni stack as an HTTP
-// server. The addr string takes the same format as http.ListenAndServe.
+// server. The addr string, if provided, takes the same format as http.ListenAndServe.
+// If no address is provided but the PORT environment variable is set, this latest will be used.
+// If neither is provided, the address' value will equal the DefaultAddress constant.
 func (n *Negroni) Run(addr ...string) {
 	l := log.New(os.Stdout, "[negroni] ", 0)
 	l.Printf("listening on %s", addr)

--- a/negroni_test.go
+++ b/negroni_test.go
@@ -3,6 +3,7 @@ package negroni
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"testing"
 )
@@ -117,4 +118,19 @@ func TestNegroni_Use_Nil(t *testing.T) {
 
 	n := New()
 	n.Use(nil)
+}
+
+func TestDetectAddress(t *testing.T) {
+	if detectAddress() != DefaultAddress {
+		t.Error("Expected the DefaultAddress")
+	}
+
+	if detectAddress(":6060") != ":6060" {
+		t.Error("Expected the provided address")
+	}
+
+	os.Setenv("PORT", "8080")
+	if detectAddress() != ":8080" {
+		t.Error("Expected the PORT env var with a prefixed colon")
+	}
 }


### PR DESCRIPTION
It's quite common in the world of HTTP server
to have the following scenarios:

- Using the 8080 port as default
- If a "PORT" environment variable is set, we use this one
- Set the address directly in the code

By using ellipsis, it is possible to use one scenario from the three without
breaking the backwards compatibility.