### PR TITLE
Add support for HTTP/2 pusher support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ go:
 - 1.5.x
 - 1.6.x
 - 1.7.x
+- 1.8.x
 - master
 
 before_install:

--- a/response_writer_pusher.go
+++ b/response_writer_pusher.go
@@ -1,0 +1,16 @@
+//+build go1.8
+
+package negroni
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (rw *responseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := rw.ResponseWriter.(http.Pusher)
+	if ok {
+		return pusher.Push(target, opts)
+	}
+	return fmt.Errorf("the ResponseWriter doesn't support the Pusher interface")
+}

--- a/response_writer_pusher_test.go
+++ b/response_writer_pusher_test.go
@@ -1,0 +1,35 @@
+//+build go1.8
+
+package negroni
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type pusherRecorder struct {
+	*httptest.ResponseRecorder
+	pushed bool
+}
+
+func newPusherRecorder() *pusherRecorder {
+	return &pusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+}
+
+func (c *pusherRecorder) Push(target string, opts *http.PushOptions) error {
+	c.pushed = true
+	return nil
+}
+
+func TestResponseWriterPush(t *testing.T) {
+	pushable := newPusherRecorder()
+	rw := NewResponseWriter(pushable)
+	pusher, ok := rw.(http.Pusher)
+	expect(t, ok, true)
+	err := pusher.Push("", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	expect(t, pushable.pushed, true)
+}


### PR DESCRIPTION
Only supported by Go 1.8+

Closes #173