### PR TITLE
Add function WrapFunc, used to converts a http.HandlerFunc into a negroni.Handler

### DIFF
--- a/negroni.go
+++ b/negroni.go
@@ -48,6 +48,16 @@ func Wrap(handler http.Handler) Handler {
 	})
 }
 
+// WrapFunc converts a http.HandlerFunc into a negroni.Handler so it can be used as a Negroni
+// middleware. The next http.HandlerFunc is automatically called after the Handler
+// is executed.
+func WrapFunc(handlerFunc http.HandlerFunc) Handler {
+	return HandlerFunc(func(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+		handlerFunc(rw, r)
+		next(rw, r)
+	})
+}
+
 // Negroni is a stack of Middleware Handlers that can be invoked as an http.Handler.
 // Negroni middleware is evaluated in the order that they are added to the stack using
 // the Use and UseHandler methods.

--- a/negroni_test.go
+++ b/negroni_test.go
@@ -134,3 +134,34 @@ func TestDetectAddress(t *testing.T) {
 		t.Error("Expected the PORT env var with a prefixed colon")
 	}
 }
+
+func voidHTTPHandlerFunc(rw http.ResponseWriter, r *http.Request) {
+	// Do nothing
+}
+
+// Test for function Wrap
+func TestWrap(t *testing.T) {
+	response := httptest.NewRecorder()
+
+	handler := Wrap(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(response, (*http.Request)(nil), voidHTTPHandlerFunc)
+
+	expect(t, response.Code, http.StatusOK)
+}
+
+// Test for function WrapFunc
+func TestWrapFunc(t *testing.T) {
+	response := httptest.NewRecorder()
+
+	// WrapFunc(f) equals Wrap(http.HandlerFunc(f)), it's simpler and usefull.
+	handler := WrapFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+
+	handler.ServeHTTP(response, (*http.Request)(nil), voidHTTPHandlerFunc)
+
+	expect(t, response.Code, http.StatusOK)
+}


### PR DESCRIPTION
I just add a function called WrapFunc, make easily for wrap a http.HandlerFunc into a negroni.Handler.