### PR TITLE
Added Request as part of logger struct

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -19,6 +19,7 @@ type LoggerEntry struct {
 	Hostname  string
 	Method    string
 	Path      string
+	Request   *http.Request
 }
 
 // LoggerDefaultFormat is the format
@@ -72,6 +73,7 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		Hostname:  r.Host,
 		Method:    r.Method,
 		Path:      r.URL.Path,
+		Request:   r,
 	}
 
 	buff := &bytes.Buffer{}

--- a/logger_test.go
+++ b/logger_test.go
@@ -5,15 +5,16 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
 func Test_Logger(t *testing.T) {
-	buff := bytes.NewBufferString("")
+	var buff bytes.Buffer
 	recorder := httptest.NewRecorder()
 
 	l := NewLogger()
-	l.ALogger = log.New(buff, "[negroni] ", 0)
+	l.ALogger = log.New(&buff, "[negroni] ", 0)
 
 	n := New()
 	// replace log for testing
@@ -30,4 +31,29 @@ func Test_Logger(t *testing.T) {
 	n.ServeHTTP(recorder, req)
 	expect(t, recorder.Code, http.StatusNotFound)
 	refute(t, len(buff.String()), 0)
+}
+
+func Test_LoggerCustomFormat(t *testing.T) {
+	var buff bytes.Buffer
+	recorder := httptest.NewRecorder()
+
+	l := NewLogger()
+	l.ALogger = log.New(&buff, "[negroni] ", 0)
+	l.SetFormat("{{.Request.URL.Query.Get \"foo\"}} {{.Request.UserAgent}} - {{.Status}}")
+
+	n := New()
+	n.Use(l)
+	n.UseHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte("OK"))
+	}))
+
+	userAgent := "Negroni-Test"
+	req, err := http.NewRequest("GET", "http://localhost:3000/foobar?foo=bar", nil)
+	if err != nil {
+		t.Error(err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	n.ServeHTTP(recorder, req)
+	expect(t, strings.TrimSpace(buff.String()), "[negroni] bar "+userAgent+" - 200")
 }


### PR DESCRIPTION
This takes care of all enhancement requests to add new logging fields as the entire request pointer is now embedded. 

The default format is unchanged so the user API is intact. To customize the format, the user just has to call the `.SetFormat()` function and set appropriate format. 

Closes #136 
Closes #192 