### PR TITLE
Custom recovery output and HTML pretty print

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ You can customize the output process by using the `SetFormatter()` function.
 
 You can use also the `HTMLPanicFormatter` to display a pretty HTML when a crash occurs.
 
+<!-- { "interrupt": true } -->
 ``` go
 package main
 
@@ -429,7 +430,7 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.SetFormatter(&HTMLPanicFormatter{})
+  recovery.Formatter = &negroni.HTMLPanicFormatter{}
   n.Use(recovery)
   n.UseHandler(mux)
 

--- a/README.md
+++ b/README.md
@@ -407,6 +407,35 @@ func reportToSentry(error interface{}) {
 }
 ```
 
+The middleware simply output the informations on STDOUT by default.
+You can customize the output process by using the `SetFormatter()` function.
+
+You can use also the `HTMLPanicFormatter` to display a pretty HTML when a crash occurs.
+
+``` go
+package main
+
+import (
+  "net/http"
+
+  "github.com/urfave/negroni"
+)
+
+func main() {
+  mux := http.NewServeMux()
+  mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+    panic("oh no")
+  })
+
+  n := negroni.New()
+  recovery := negroni.NewRecovery()
+  recovery.SetFormatter(&HTMLPanicFormatter{})
+  n.Use(recovery)
+  n.UseHandler(mux)
+
+  http.ListenAndServe(":3003", n)
+}
+```
 
 ## Logger
 

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -80,12 +80,12 @@ func newTestOutput() *testOutput {
 	return &testOutput{buf}
 }
 
-func (t *testOutput) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformations) {
+func (t *testOutput) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformation) {
 	fmt.Fprintf(t, formatInfos(infos))
 }
 
-func formatInfos(infos *PanicInformations) string {
-	return fmt.Sprintf("%s %s", infos.RequestDescription(), infos.RecoveredElement)
+func formatInfos(infos *PanicInformation) string {
+	return fmt.Sprintf("%s %s", infos.RequestDescription(), infos.RecoveredPanic)
 }
 func TestRecovery_formatter(t *testing.T) {
 	recorder := httptest.NewRecorder()
@@ -93,10 +93,10 @@ func TestRecovery_formatter(t *testing.T) {
 
 	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", nil)
 	var element interface{} = "here is a panic!"
-	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
+	expectedInfos := &PanicInformation{RecoveredPanic: element, Request: req}
 
 	rec := NewRecovery()
-	rec.SetFormatter(formatter)
+	rec.Formatter = formatter
 	n := New()
 	n.Use(rec)
 	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
@@ -108,35 +108,35 @@ func TestRecovery_formatter(t *testing.T) {
 	expect(t, formatInfos(expectedInfos), formatter.String())
 }
 
-func TestRecovery_PanicInformations(t *testing.T) {
+func TestRecovery_PanicInformation(t *testing.T) {
 	// Request with query
 	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", nil)
 	var element interface{} = "here is a panic!"
-	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
+	expectedInfos := &PanicInformation{RecoveredPanic: element, Request: req}
 
 	expect(t, expectedInfos.RequestDescription(), "GET /somePath?element=true")
 
 	// Request without Query
 	req, _ = http.NewRequest("POST", "http://localhost:3003/somePath", nil)
 	element = "here is a panic!"
-	expectedInfos = &PanicInformations{RecoveredElement: element, Request: req}
+	expectedInfos = &PanicInformation{RecoveredPanic: element, Request: req}
 
 	expect(t, expectedInfos.RequestDescription(), "POST /somePath")
 
 	// Nil request
-	expectedInfos = &PanicInformations{RecoveredElement: element, Request: nil}
+	expectedInfos = &PanicInformation{RecoveredPanic: element, Request: nil}
 	expect(t, expectedInfos.RequestDescription(), nilRequestMessage)
 
 	// Stack
 	stackValue := "Some Stack element"
-	expectedInfos = &PanicInformations{RecoveredElement: element, Request: req, Stack: []byte(stackValue)}
+	expectedInfos = &PanicInformation{RecoveredPanic: element, Request: req, Stack: []byte(stackValue)}
 	expect(t, expectedInfos.StackAsString(), stackValue)
 }
 
 func TestRecovery_HTMLFormatter(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	rec := NewRecovery()
-	rec.SetFormatter(&HTMLPanicFormatter{})
+	rec.Formatter = &HTMLPanicFormatter{}
 	n := New()
 	n.Use(rec)
 	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -2,6 +2,7 @@ package negroni
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -68,4 +69,81 @@ func TestRecovery_callbackPanic(t *testing.T) {
 	n.ServeHTTP(recorder, (*http.Request)(nil))
 
 	expect(t, strings.Contains(buff.String(), "callback panic"), true)
+}
+
+type testOutput struct {
+	*bytes.Buffer
+}
+
+func newTestOutput() *testOutput {
+	buf := bytes.NewBufferString("")
+	return &testOutput{buf}
+}
+
+func (t *testOutput) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformations) {
+	fmt.Fprintf(t, formatInfos(infos))
+}
+
+func formatInfos(infos *PanicInformations) string {
+	return fmt.Sprintf("%s %s", infos.RequestDescription(), infos.RecoveredElement)
+}
+func TestRecovery_formatter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	formatter := newTestOutput()
+
+	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", http.NoBody)
+	var element interface{} = "here is a panic!"
+	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
+
+	rec := NewRecovery()
+	rec.SetFormatter(formatter)
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		panic(element)
+	}))
+
+	n.ServeHTTP(recorder, req)
+
+	expect(t, formatInfos(expectedInfos), formatter.String())
+}
+
+func TestRecovery_PanicInformations(t *testing.T) {
+	// Request with query
+	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", http.NoBody)
+	var element interface{} = "here is a panic!"
+	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
+
+	expect(t, expectedInfos.RequestDescription(), "GET /somePath?element=true")
+
+	// Request without Query
+	req, _ = http.NewRequest("POST", "http://localhost:3003/somePath", http.NoBody)
+	element = "here is a panic!"
+	expectedInfos = &PanicInformations{RecoveredElement: element, Request: req}
+
+	expect(t, expectedInfos.RequestDescription(), "POST /somePath")
+
+	// Nil request
+	expectedInfos = &PanicInformations{RecoveredElement: element, Request: nil}
+	expect(t, expectedInfos.RequestDescription(), nilRequestMessage)
+
+	// Stack
+	stackValue := "Some Stack element"
+	expectedInfos = &PanicInformations{RecoveredElement: element, Request: req, Stack: []byte(stackValue)}
+	expect(t, expectedInfos.StackAsString(), stackValue)
+}
+
+func TestRecovery_HTMLFormatter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	rec := NewRecovery()
+	rec.SetFormatter(&HTMLPanicFormatter{})
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		panic("some panic")
+	}))
+
+	n.ServeHTTP(recorder, (*http.Request)(nil))
+	expect(t, recorder.Header().Get("Content-Type"), "text/html; charset=utf-8")
+	refute(t, recorder.Body.Len(), 0)
 }

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -91,7 +91,7 @@ func TestRecovery_formatter(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	formatter := newTestOutput()
 
-	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", http.NoBody)
+	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", nil)
 	var element interface{} = "here is a panic!"
 	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
 
@@ -110,14 +110,14 @@ func TestRecovery_formatter(t *testing.T) {
 
 func TestRecovery_PanicInformations(t *testing.T) {
 	// Request with query
-	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", http.NoBody)
+	req, _ := http.NewRequest("GET", "http://localhost:3003/somePath?element=true", nil)
 	var element interface{} = "here is a panic!"
 	expectedInfos := &PanicInformations{RecoveredElement: element, Request: req}
 
 	expect(t, expectedInfos.RequestDescription(), "GET /somePath?element=true")
 
 	// Request without Query
-	req, _ = http.NewRequest("POST", "http://localhost:3003/somePath", http.NoBody)
+	req, _ = http.NewRequest("POST", "http://localhost:3003/somePath", nil)
 	element = "here is a panic!"
 	expectedInfos = &PanicInformations{RecoveredElement: element, Request: req}
 


### PR DESCRIPTION
Largely based on this [work](https://github.com/go-martini/martini/pull/156/commits), 
this PR extends the `Recovery` struct with a `formatter` property that allows to customize the output process.

I also added a `HTMLPanicFormatter` class that output the stack trace inside one HTML page.
As I am not so skilled in frontend, I just used the HTML code from the Martini PR.

I also updated the english `README.md` and added some tests.


 