### PR TITLE
Send stack and Request to Recovery middleware callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ handler if the request does not match a file on the filesystem.
 This middleware catches `panic`s and responds with a `500` response code. If
 any other middleware has written a response code or body, this middleware will
 fail to properly send a 500 to the client, as the client has already received
-the HTTP response code. Additionally, an `ErrorHandlerFunc` can be attached
+the HTTP response code. Additionally, an `PanicHandlerFunc` can be attached
 to report 500's to an error reporting service such as Sentry or Airbrake.
 
 Example:
@@ -396,14 +396,14 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.ErrorHandlerFunc = reportToSentry
+  recovery.PanicHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
 }
 
-func reportToSentry(error interface{}) {
+func reportToSentry(info *negroni.PanicInformation) {
     // write code here to report error to Sentry
 }
 ```

--- a/recovery.go
+++ b/recovery.go
@@ -130,10 +130,13 @@ type Recovery struct {
 	Logger           ALogger
 	PrintStack       bool
 	PanicHandlerFunc func(*PanicInformation)
-	ErrorHandlerFunc func(interface{})
 	StackAll         bool
 	StackSize        int
 	Formatter        PanicFormatter
+
+	// Deprecated: Use PanicHandlerFunc instead to receive panic
+	// error with additional information (see PanicInformation)
+	ErrorHandlerFunc func(interface{})
 }
 
 // NewRecovery returns a new instance of Recovery

--- a/translations/README_fr_FR.md
+++ b/translations/README_fr_FR.md
@@ -336,7 +336,7 @@ Ce *middleware* attrape les appels à `panic` et renvoie une response `500` à
 la requête correspondante. Si un autre *middleware* a déjà renvoyé une réponse (vide ou non), 
 le renvoie de la réponse `500` au client échouera, le client en ayant déja obtenu une.
 
-Il est possible d'ajoindre au *middleware* une fonction de type `ErrorHandlerFunc` 
+Il est possible d'ajoindre au *middleware* une fonction de type `PanicHandlerFunc` 
 pour collecter les erreurs `500` et les transmettre à un service de rapport d'erreur
 tels Sentry ou Airbrake.
 
@@ -369,7 +369,7 @@ func main() {
 Ce programme renverra une erreur `500 Internal Server Error` à chaque requête reçue.
 Il transmettra à son *logger* associé la trace de la pile d'exécution et affichera cette même trace sur la sortie standard si la valeur `PrintStack` est mise à `true`. (valeur par défaut)
 
-Exemple avec l'utilisation d'une `ErrorHandlerFunc`:
+Exemple avec l'utilisation d'une `PanicHandlerFunc`:
 
 ``` go
 package main
@@ -388,14 +388,14 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.ErrorHandlerFunc = reportToSentry
+  recovery.PanicHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
 }
 
-func reportToSentry(error interface{}) {
+func reportToSentry(info *negroni.PanicInformation) {
     // code envoyant le rapport d'erreur à Sentry
 }
 ```

--- a/translations/README_pt_br.md
+++ b/translations/README_pt_br.md
@@ -315,7 +315,7 @@ próximo handler se a requisição não encontrar um arquivo no filesystem.
 Este middleware pega repostas de `panic` com um código de resposta `500`. Se
 algum outro middleware escreveu um código resposta ou conteúdo, este middleware
 falhará corretamente enviando um 500 para o cliente, como o cliente já recebeu
-o código de resposta HTTP. Adicionalmente um `ErrorHandlerFunc` pode ser anexado
+o código de resposta HTTP. Adicionalmente um `PanicHandlerFunc` pode ser anexado
 para reportar 500 para um serviço de report como um Sentry ou Airbrake.
 
 Exemplo:
@@ -367,14 +367,14 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.ErrorHandlerFunc = reportToSentry
+  recovery.PanicHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
 }
 
-func reportToSentry(error interface{}) {
+func reportToSentry(info *negroni.PanicInformation) {
     // write code here to report error to Sentry
 }
 ```

--- a/translations/README_zh_CN.md
+++ b/translations/README_zh_CN.md
@@ -302,7 +302,7 @@ func main() {
 ### 恢复
 
 本中间件接收 `panic` 跟错误代码 `500` 的响应。如果其他中间件写了响应代码或 Body 内容的话, 中间件会无法顺利地传送 500 错误给客户端, 因为客户端
-已经收到 HTTP 响应。另外, 可以 像 Sentry 或 Airbrake 挂载 `ErrorHandlerFunc` 来报 500 错误给系统。
+已经收到 HTTP 响应。另外, 可以 像 Sentry 或 Airbrake 挂载 `PanicHandlerFunc` 来报 500 错误给系统。
 
 例子:
 
@@ -352,14 +352,14 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.ErrorHandlerFunc = reportToSentry
+  recovery.PanicHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
 }
 
-func reportToSentry(error interface{}) {
+func reportToSentry(info *negroni.PanicInformation) {
     // 在这写些程式回报错误给Sentry
 }
 ```

--- a/translations/README_zh_tw.md
+++ b/translations/README_zh_tw.md
@@ -287,7 +287,7 @@ func main() {
 
 本中介器接收`panic`跟錯誤代碼`500`的回應. 如果其他任何中介器寫了回應
 的HTTP代碼或內容的話, 中介器會無法順利地傳送500給用戶端, 因為用戶端
-已經收到HTTP的回應代碼. 另外, 可以掛載`ErrorHandlerFunc`來回報500
+已經收到HTTP的回應代碼. 另外, 可以掛載`PanicHandlerFunc`來回報500
 的錯誤到錯誤回報系統, 如: Sentry或Airbrake.
 
 範例:
@@ -339,14 +339,14 @@ func main() {
 
   n := negroni.New()
   recovery := negroni.NewRecovery()
-  recovery.ErrorHandlerFunc = reportToSentry
+  recovery.PanicHandlerFunc = reportToSentry
   n.Use(recovery)
   n.UseHandler(mux)
 
   http.ListenAndServe(":3003", n)
 }
 
-func reportToSentry(error interface{}) {
+func reportToSentry(info *negroni.PanicInformation) {
     // 在這寫些程式回報錯誤給Sentry
 }
 ```


### PR DESCRIPTION
When integrating Recovery middleware with an exception notifier (Airbrake -
 https://github.com/airbrake/gobrake), I found that having just the error in `ErrorHandlerFunc` is too limiting in tracking the cause (i.e. http.Request) of the exception.

This PR keeps the current `ErrorHandlerFunc` API for backward compatibility, but adds a new `PanicHandlerFunc` that receives the `PanicInformation` that includes both error and request.