### PR TITLE
Log paths containing percent (%) character correctly

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -2,7 +2,6 @@ package negroni
 
 import (
 	"bytes"
-	"strings"
 
 	"log"
 	"net/http"
@@ -73,11 +72,11 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		Duration:  time.Since(start),
 		Hostname:  r.Host,
 		Method:    r.Method,
-		Path:      strings.Replace(r.URL.Path, "%", "%%", -1),
+		Path:      r.URL.Path,
 		Request:   r,
 	}
 
 	buff := &bytes.Buffer{}
 	l.template.Execute(buff, log)
-	l.Printf(buff.String())
+	l.Println(buff.String())
 }

--- a/logger.go
+++ b/logger.go
@@ -2,6 +2,7 @@ package negroni
 
 import (
 	"bytes"
+	"strings"
 
 	"log"
 	"net/http"
@@ -72,7 +73,7 @@ func (l *Logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 		Duration:  time.Since(start),
 		Hostname:  r.Host,
 		Method:    r.Method,
-		Path:      r.URL.Path,
+		Path:      strings.Replace(r.URL.Path, "%", "%%", -1),
 		Request:   r,
 	}
 

--- a/logger.go
+++ b/logger.go
@@ -10,8 +10,7 @@ import (
 	"time"
 )
 
-// LoggerEntry is the structure
-// passed to the template.
+// LoggerEntry is the structure passed to the template.
 type LoggerEntry struct {
 	StartTime string
 	Status    int
@@ -22,13 +21,10 @@ type LoggerEntry struct {
 	Request   *http.Request
 }
 
-// LoggerDefaultFormat is the format
-// logged used by the default Logger instance.
-var LoggerDefaultFormat = "{{.StartTime}} | {{.Status}} | \t {{.Duration}} | {{.Hostname}} | {{.Method}} {{.Path}} \n"
+// LoggerDefaultFormat is the format logged used by the default Logger instance.
+var LoggerDefaultFormat = "{{.StartTime}} | {{.Status}} | \t {{.Duration}} | {{.Hostname}} | {{.Method}} {{.Path}}"
 
-// LoggerDefaultDateFormat is the
-// format used for date by the
-// default Logger instance.
+// LoggerDefaultDateFormat is the format used for date by the default Logger instance.
 var LoggerDefaultDateFormat = time.RFC3339
 
 // ALogger interface

--- a/logger_test.go
+++ b/logger_test.go
@@ -33,6 +33,33 @@ func Test_Logger(t *testing.T) {
 	refute(t, len(buff.String()), 0)
 }
 
+func Test_LoggerURLEncodedString(t *testing.T) {
+	var buff bytes.Buffer
+	recorder := httptest.NewRecorder()
+
+	l := NewLogger()
+	l.ALogger = log.New(&buff, "[negroni] ", 0)
+	l.SetFormat("{{.Path}}")
+
+	n := New()
+	// replace log for testing
+	n.Use(l)
+	n.UseHandler(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	}))
+
+	// Test reserved characters - !*'();:@&=+$,/?%#[]
+	req, err := http.NewRequest("GET", "http://localhost:3000/%21%2A%27%28%29%3B%3A%40%26%3D%2B%24%2C%2F%3F%25%23%5B%5D", nil)
+	if err != nil {
+		t.Error(err)
+	}
+
+	n.ServeHTTP(recorder, req)
+	expect(t, recorder.Code, http.StatusOK)
+	expect(t, strings.TrimSpace(buff.String()), "[negroni] /!*'();:@&=+$,/?%#[]")
+	refute(t, len(buff.String()), 0)
+}
+
 func Test_LoggerCustomFormat(t *testing.T) {
 	var buff bytes.Buffer
 	recorder := httptest.NewRecorder()


### PR DESCRIPTION
Bugfix for #222 