### PR TITLE
Copy the slice of handlers in Negroni.With()

### DIFF
--- a/negroni.go
+++ b/negroni.go
@@ -77,8 +77,10 @@ func New(handlers ...Handler) *Negroni {
 // With returns a new Negroni instance that is a combination of the negroni
 // receiver's handlers and the provided handlers.
 func (n *Negroni) With(handlers ...Handler) *Negroni {
+	currentHandlers := make([]Handler, len(n.handlers))
+	copy(currentHandlers, n.handlers)
 	return New(
-		append(n.handlers, handlers...)...,
+		append(currentHandlers, handlers...)...,
 	)
 }
 


### PR DESCRIPTION
Otherwise you can end up with subsequent Use* calls on the child
middlewares modifying the original Negroni instance if the slice was not
reallocated during the append().

I believe this to be the original intent of the With() function given
it's signature of returning a new Negroni instance.

Fixes #239 