### PR TITLE
Only send panic text if PrintStack true

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -163,13 +163,12 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 
 			if rec.PrintStack {
 				infos.Stack = stack
+				rec.Formatter.FormatPanicError(rw, r, infos)
 			}
-			
+
 			if rec.LogStack {
 				rec.Logger.Printf(panicText, err, stack)
 			}
-
-			rec.Formatter.FormatPanicError(rw, r, infos)
 
 			if rec.ErrorHandlerFunc != nil {
 				func() {


### PR DESCRIPTION
Fixes #244 

## What
Only print `panic` text if `PrintStack` is true.

## Why
The previous implementation would make sure that the stack wasn't sent unless `PrintStack` was set to `true`, but would nonetheless send whatever text was passed to `panic()`. This is bad for two reasons:

1. it creates a security risk by leaking information about the server's internal functioning
2. it creates unexpected behavior for the developer who expects that setting `PrintStack` to `false` would suppress **all** stack trace information including the panic text.