### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/negroni.go
+++ b/negroni.go
@@ -144,7 +144,7 @@ func detectAddress(addr ...string) string {
 	return DefaultAddress
 }
 
-// Returns a list of all the handlers in the current Negroni middleware chain.
+// Handlers returns a list of all the handlers in the current Negroni middleware chain.
 func (n *Negroni) Handlers() []Handler {
 	return n.handlers
 }


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say **`opt out`** to opt out of future CodeLingo outreach PRs.*