### PR TITLE
perf: reduce memory allocate per request (5x faster)

### DIFF
--- a/negroni_bench_test.go
+++ b/negroni_bench_test.go
@@ -1,0 +1,33 @@
+package negroni
+
+import (
+	"net/http"
+	"testing"
+)
+
+type voidHandler struct{}
+
+func (vh *voidHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	next(rw, r)
+}
+
+func BenchmarkNegroni(b *testing.B) {
+	h1 := &voidHandler{}
+	h2 := &voidHandler{}
+	h3 := &voidHandler{}
+	h4 := &voidHandler{}
+	h5 := &voidHandler{}
+	h6 := &voidHandler{}
+	h7 := &voidHandler{}
+	h8 := &voidHandler{}
+	h9 := &voidHandler{}
+	h10 := &voidHandler{}
+
+	n := New(h1, h2, h3, h4, h5, h6, h7, h8, h9, h10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		n.ServeHTTP(nil, nil)
+	}
+}


### PR DESCRIPTION
Hello.

When pass the m.next.ServeHTTP to function, Go runtime will allocate temporary struct as follow:

````bash
type.noalg.struct { F uintptr; R "".middleware }(SB), AX
````

To reduce the memory allocate, we use `nextfn` to store it. The benchmark as the following:

````bash
name       old time/op    new time/op    delta
Negroni-8     832ns ± 0%     150ns ± 0%   ~     (p=1.000 n=1+1)

name       old alloc/op   new alloc/op   delta
Negroni-8      592B ± 0%       64B ± 0%   ~     (p=1.000 n=1+1)

name       old allocs/op  new allocs/op  delta
Negroni-8      12.0 ± 0%       1.0 ± 0%   ~     (p=1.000 n=1+1)
````

Signed-off-by: detailyang <detailyang@gmail.com>


BTW: There is a bonus tip to reduce memory (zero allocate) which reuses the `NewResponseWriter` via sync.pool