### PR TITLE
Added power support "old go version jobs are excluded "

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,10 @@ language: go
 
 sudo: false
 dist: trusty
-
+arch:
+  - AMD64
+  - ppc64le
+  
 go:
 - 1.x
 - 1.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,29 @@ go:
 - 1.11.x
 - master
 
+# Disable version 1.x, 1.2.x, 1.3.x, 1.4.x, 1.5.x, 1.6.x, 1.7.x, 1.8.x, 1.9.x, 1.10.x 
+jobs: 
+  exclude:
+    - arch: ppc64le
+      go: 1.x 
+    - arch: ppc64le
+      go: 1.2.x
+    - arch: ppc64le
+      go: 1.3.x 
+    - arch: ppc64le
+      go: 1.4.x
+    - arch: ppc64le
+      go: 1.5.x
+    - arch: ppc64le
+      go: 1.6.x
+    - arch: ppc64le
+      go: 1.7.x
+    - arch: ppc64le
+      go: 1.8.x
+    - arch: ppc64le
+      go: 1.9.x
+    - arch: ppc64le
+      go: 1.10.x
 before_install:
 - find "${GOPATH%%:*}" -name '*.a' -delete
 - rm -rf "${GOPATH%%:*}/src/golang.org"


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.