### PR TITLE
replace multiple slashes at the beginning of path with a single one

### DIFF
--- a/static.go
+++ b/static.go
@@ -65,6 +65,9 @@ func (s *Static) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.Ha
 	if fi.IsDir() {
 		// redirect if missing trailing slash
 		if !strings.HasSuffix(r.URL.Path, "/") {
+			if strings.HasPrefix(r.URL.Path, "//") {
+				r.URL.Path = "/" + strings.TrimLeft(r.URL.Path, "/")
+			}
 			http.Redirect(rw, r, r.URL.Path+"/", http.StatusFound)
 			return
 		}


### PR DESCRIPTION
This resolves an open-redirect security vulnerability.