### PR TITLE
feat: ResponseWriter status should not be changed if written twice

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -48,6 +48,9 @@ type responseWriter struct {
 }
 
 func (rw *responseWriter) WriteHeader(s int) {
+	if rw.Written() {
+		return
+	}
 	rw.status = s
 	rw.callBefore()
 	rw.ResponseWriter.WriteHeader(s)

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -106,6 +106,19 @@ func TestResponseWriterWritingHeader(t *testing.T) {
 	expect(t, rw.Size(), 0)
 }
 
+func TestResponseWriterWritingHeaderTwice(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.WriteHeader(http.StatusNotFound)
+	rw.WriteHeader(http.StatusInternalServerError)
+
+	expect(t, rec.Code, rw.Status())
+	expect(t, rec.Body.String(), "")
+	expect(t, rw.Status(), http.StatusNotFound)
+	expect(t, rw.Size(), 0)
+}
+
 func TestResponseWriterBefore(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)


### PR DESCRIPTION
If the status of `ResponseWriter` could be changed after written, some there would be a magical phenomenon

We have a code snippet like this
```Go
rw.WriteHeader(http.StatusNotFound)
rw.WriteHeader(http.StatusInternalServerError)
```
and we have a middleware for logging or other cases, we want to get the status `500`
```Go
rw.Status() // 500 Internal Server Error
```
but actually we would get
```http
HTTP/1.1 404 Not Found
```