### PR TITLE
fix: let ResponseWriter.Before() callbacks change status

### DIFF
--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -69,6 +69,34 @@ func TestResponseWriterBeforeFuncHasAccessToStatus(t *testing.T) {
 	expect(t, status, http.StatusCreated)
 }
 
+func TestResponseWriterBeforeFuncCanChangeStatus(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	// Always respond with 200.
+	rw.Before(func(w ResponseWriter) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rw.WriteHeader(http.StatusBadRequest)
+	expect(t, rec.Code, http.StatusOK)
+}
+
+func TestResponseWriterBeforeFuncChangesStatusMultipleTimes(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	rw.Before(func(w ResponseWriter) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	rw.Before(func(w ResponseWriter) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	rw.WriteHeader(http.StatusOK)
+	expect(t, rec.Code, http.StatusNotFound)
+}
+
 func TestResponseWriterWritingString(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)


### PR DESCRIPTION
Starting with v3, calls to WriteHeader() from within a ResponseWriter.Before() callback wouldn't change the returned HTTP status.

fixes #270