### PR TITLE
Added ResponseWriter.Unwrap() for ResponseController

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -84,6 +84,11 @@ func (rw *responseWriter) ReadFrom(r io.Reader) (n int64, err error) {
 	return
 }
 
+// Satisfy http.ResponseController support (Go 1.20+)
+func (rw *responseWriter) Unwrap() http.ResponseWriter {
+	return rw.ResponseWriter
+}
+
 func (rw *responseWriter) Status() int {
 	if rw.Written() {
 		return rw.status

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -169,6 +169,17 @@ func TestResponseWriterBefore(t *testing.T) {
 	expect(t, result, "barfoo")
 }
 
+func TestResponseWriterUnwrap(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+	switch v := rw.(type) {
+	case interface{ Unwrap() http.ResponseWriter }:
+		expect(t, v.Unwrap(), rec)
+	default:
+		t.Error("Does not implement Unwrap()")
+	}
+}
+
 func TestResponseWriterHijack(t *testing.T) {
 	hijackable := newHijackableResponse()
 	rw := NewResponseWriter(hijackable)


### PR DESCRIPTION
Introduced in Go 1.20, `net.ResponseController` relies on `Unwrap()` method to make calls to the original `http.ResponseWriter`. Without it, calling `SetReadDeadline` and `SetWriteDeadline` returns `"feature not supported"`.