### PR TITLE
Fix issue resulting in HTTP 200 being returned for request/responses using 100-continue that should actually return 201, 400, 500, etc.

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -102,7 +102,7 @@ func (rw *responseWriter) Size() int {
 }
 
 func (rw *responseWriter) Written() bool {
-	return rw.status != 0
+	return rw.status >= http.StatusOK || rw.status == http.StatusSwitchingProtocols // treat all 1xx codes aside from SwitchingProtocols as non-terminal
 }
 
 func (rw *responseWriter) Before(before func(ResponseWriter)) {

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -110,6 +110,29 @@ func TestResponseWriterWritingString(t *testing.T) {
 	expect(t, rw.Written(), true)
 }
 
+func TestResponseWriterWrittenStatusCode(t *testing.T) {
+	rec := httptest.NewRecorder()
+	rw := NewResponseWriter(rec)
+
+	expect(t, rw.Written(), false)
+	for status := http.StatusContinue; status <= http.StatusEarlyHints; status++ {
+		if status == http.StatusSwitchingProtocols {
+			continue
+		}
+		rw.WriteHeader(status)
+		expected := false
+		expect(t, rw.Written(), expected)
+	}
+	rw.WriteHeader(http.StatusCreated)
+	expect(t, rw.Written(), true)
+
+	rw2 := NewResponseWriter(rec)
+	expect(t, rw2.Written(), false)
+	rw2.WriteHeader(http.StatusSwitchingProtocols)
+	expect(t, rw2.Written(), true)
+
+}
+
 func TestResponseWriterWritingStrings(t *testing.T) {
 	rec := httptest.NewRecorder()
 	rw := NewResponseWriter(rec)


### PR DESCRIPTION
HTTP 1xx's are interim status codes to be followed up by another. Prior to this change, if a response code for 100 Continue was written, any follow up call to WriteHeader was a no-op, and resulted in responses always receiving a 200 OK, even if WriteHeader was a 201, 404, 500, etc.

This fixes the issue seen in https://github.com/cloudfoundry/routing-release/issues/409, which started occurring as of the negroni code change https://github.com/urfave/negroni/commit/ec1c41c0c3d4d6688ca8dcd45cbb23a1f9e020a8.