### PR TITLE
Fix for Go 1.24

### DIFF
--- a/recovery_test.go
+++ b/recovery_test.go
@@ -106,7 +106,7 @@ func newTestOutput() *testOutput {
 }
 
 func (t *testOutput) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformation) {
-	fmt.Fprintf(t, formatInfos(infos))
+	fmt.Fprint(t, formatInfos(infos))
 }
 
 func formatInfos(infos *PanicInformation) string {


### PR DESCRIPTION
Go 1.24 no longer allows dynamic format string.

```
./recovery_test.go:109:17: non-constant format string in call to fmt.Fprintf
FAIL    github.com/urfave/negroni [build failed]
```