### PR TITLE
docs: highlight /v3 module import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 `github.com/codegangsta/negroni` -- Github will automatically redirect requests
 to this repository, but we recommend updating your references for clarity.
 
+**Import path:** use the current major module path
+`github.com/urfave/negroni/v3` (v3 is the latest release). Older docs and
+copy-pasted snippets may still show `github.com/urfave/negroni` without `/v3`.
+
 Negroni is an idiomatic approach to web middleware in Go. It is tiny,
 non-intrusive, and encourages use of `net/http` Handlers.
 

--- a/doc.go
+++ b/doc.go
@@ -4,12 +4,15 @@
 //
 // For a full guide visit http://github.com/urfave/negroni
 //
+// The module path for the current major version is github.com/urfave/negroni/v3.
+//
 //  package main
 //
 //  import (
-//    "github.com/urfave/negroni"
-//    "net/http"
 //    "fmt"
+//    "net/http"
+//
+//    "github.com/urfave/negroni/v3"
 //  )
 //
 //  func main() {


### PR DESCRIPTION
## Description

Users still land on the old import path without `/v3` because package docs (`doc.go`) and the README notice did not spell out that **v3 is the current module path**.

Maintainer confirmed on #280 that v3 is safe and a docs PR is welcome.

## Fix

- README: note that import path is `github.com/urfave/negroni/v3`
- `doc.go`: package example uses `/v3`

## Tests

Docs-only.

## Linked Issue

Closes #280
