### PR TITLE
fix(recovery): allow custom formatters to set response headers

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -155,11 +155,33 @@ func NewRecovery() *Recovery {
 	}
 }
 
+// recoveryWriter forces HTTP 500 on first write while still allowing
+// PanicFormatter implementations to set headers (e.g. Content-Type) first.
+// Calling WriteHeader before FormatPanicError made those header updates a no-op (#241).
+type recoveryWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *recoveryWriter) WriteHeader(code int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	// Panic recovery always answers 500, regardless of what the formatter passes.
+	w.ResponseWriter.WriteHeader(http.StatusInternalServerError)
+}
+
+func (w *recoveryWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	return w.ResponseWriter.Write(b)
+}
+
 func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	defer func() {
 		if err := recover(); err != nil {
-			rw.WriteHeader(http.StatusInternalServerError)
-
 			infos := &PanicInformation{
 				RecoveredPanic: err,
 				Request:        r,
@@ -167,15 +189,22 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 			infos.Stack = infos.Stack[:runtime.Stack(infos.Stack, rec.StackAll)]
 
+			out := &recoveryWriter{ResponseWriter: rw}
+
 			// PrintStack will write stack trace info to the ResponseWriter if set to true!
 			// If set to false it will respond with the standard response documented here https://httpstat.us/500
+			// Headers must be set before WriteHeader/Write so custom formatters can control Content-Type (#241).
 			if rec.PrintStack && rec.Formatter != nil {
-				rec.Formatter.FormatPanicError(rw, r, infos)
-			} else {
-				if rw.Header().Get("Content-Type") == "" {
-					rw.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				rec.Formatter.FormatPanicError(out, r, infos)
+				if !out.wroteHeader {
+					out.WriteHeader(http.StatusInternalServerError)
 				}
-				fmt.Fprint(rw, NoPrintStackBodyString)
+			} else {
+				if out.Header().Get("Content-Type") == "" {
+					out.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				}
+				out.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprint(out, NoPrintStackBodyString)
 			}
 
 			if rec.LogStack {

--- a/recovery.go
+++ b/recovery.go
@@ -159,7 +159,7 @@ func NewRecovery() *Recovery {
 // PanicFormatter implementations to set headers (e.g. Content-Type) first.
 // Calling WriteHeader before FormatPanicError made those header updates a no-op (#241).
 type recoveryWriter struct {
-	http.ResponseWriter
+	ResponseWriter
 	wroteHeader bool
 }
 
@@ -189,7 +189,11 @@ func (rec *Recovery) ServeHTTP(rw http.ResponseWriter, r *http.Request, next htt
 			}
 			infos.Stack = infos.Stack[:runtime.Stack(infos.Stack, rec.StackAll)]
 
-			out := &recoveryWriter{ResponseWriter: rw}
+			responseWriter, ok := rw.(ResponseWriter)
+			if !ok {
+				responseWriter = NewResponseWriter(rw)
+			}
+			out := &recoveryWriter{ResponseWriter: responseWriter}
 
 			// PrintStack will write stack trace info to the ResponseWriter if set to true!
 			// If set to false it will respond with the standard response documented here https://httpstat.us/500

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -199,3 +199,29 @@ func TestRecovery_customFormatterHeaders(t *testing.T) {
 	expect(t, recorder.Header().Get("Content-Type"), "application/json")
 	expect(t, strings.Contains(recorder.Body.String(), "boom"), true)
 }
+
+type negroniWriterCheckFormatter struct {
+	sawNegroniWriter bool
+}
+
+func (f *negroniWriterCheckFormatter) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformation) {
+	_, f.sawNegroniWriter = rw.(ResponseWriter)
+}
+
+func TestRecovery_formatterReceivesNegroniResponseWriter(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	formatter := &negroniWriterCheckFormatter{}
+
+	rec := NewRecovery()
+	rec.Logger = log.New(bytes.NewBuffer([]byte{}), "[negroni] ", 0)
+	rec.Formatter = formatter
+
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		panic("boom")
+	}))
+	n.ServeHTTP(recorder, httptest.NewRequest("GET", "/", nil))
+
+	expect(t, formatter.sawNegroniWriter, true)
+}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -172,3 +172,30 @@ func TestRecovery_HTMLFormatter(t *testing.T) {
 	expect(t, recorder.Header().Get("Content-Type"), "text/html; charset=utf-8")
 	refute(t, recorder.Body.Len(), 0)
 }
+
+type jsonPanicFormatter struct{}
+
+func (j *jsonPanicFormatter) FormatPanicError(rw http.ResponseWriter, r *http.Request, infos *PanicInformation) {
+	rw.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(rw, `{"error":"%v"}`, infos.RecoveredPanic)
+}
+
+func TestRecovery_customFormatterHeaders(t *testing.T) {
+	// Regression for #241: custom formatters must be able to set Content-Type
+	// before the 500 status is committed.
+	recorder := httptest.NewRecorder()
+	rec := NewRecovery()
+	rec.Logger = log.New(bytes.NewBuffer([]byte{}), "[negroni] ", 0)
+	rec.Formatter = &jsonPanicFormatter{}
+
+	n := New()
+	n.Use(rec)
+	n.UseHandler(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		panic("boom")
+	}))
+	n.ServeHTTP(recorder, httptest.NewRequest("GET", "/", nil))
+
+	expect(t, recorder.Code, http.StatusInternalServerError)
+	expect(t, recorder.Header().Get("Content-Type"), "application/json")
+	expect(t, strings.Contains(recorder.Body.String(), "boom"), true)
+}


### PR DESCRIPTION
## Description

`Recovery` called `WriteHeader(500)` **before** `PanicFormatter.FormatPanicError`. Once the status is committed, later `Header().Set("Content-Type", ...)` from a custom formatter is ignored, so custom formatters cannot control response headers (#241).

### Fix

Introduce a small `recoveryWriter` that:

1. Lets the formatter set headers first
2. Forces HTTP 500 on first `Write` / `WriteHeader`
3. Still emits the standard 500 body when `PrintStack` is false

This also addresses the #269 class of issue where recovery pre-commits status/body before custom output can shape the response.

## Tests

```text
go test . -run TestRecovery -count=1
# ok
```

Added `TestRecovery_customFormatterHeaders` asserting `Content-Type: application/json` after panic.

Fixes #241
